### PR TITLE
Replace CI* field with Postgre's collation

### DIFF
--- a/src/users/migrations/0003_ci_collation.py
+++ b/src/users/migrations/0003_ci_collation.py
@@ -1,0 +1,24 @@
+"""
+Creates a collation for case-insensitive text in PostgreSQL,
+to replace Django's CI* fields.
+
+https://adamj.eu/tech/2023/02/23/migrate-django-postgresql-ci-fields-case-insensitive-collation
+"""
+
+from django.contrib.postgres.operations import CreateCollation
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0002_alter_user_email"),
+    ]
+
+    operations = [
+        CreateCollation(
+            "case_insensitive",
+            provider="icu",
+            locale="und-u-ks-level2",
+            deterministic=False,
+        ),
+    ]

--- a/src/users/migrations/0004_alter_user_email.py
+++ b/src/users/migrations/0004_alter_user_email.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0003_ci_collation"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="user",
+            name="email",
+            field=models.EmailField(
+                db_collation="case_insensitive",
+                max_length=254,
+                unique=True,
+                verbose_name="email address",
+            ),
+        ),
+    ]

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -2,7 +2,6 @@ from gettext import gettext as _
 
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.auth.models import AbstractUser
-from django.contrib.postgres.fields import CIEmailField
 from django.db import models
 
 from core.db.models import BaseModel
@@ -31,9 +30,10 @@ class User(BaseModel, AbstractUser):
     first_name = None
     last_name = None
 
-    email = CIEmailField(
+    email = models.EmailField(
         _("email address"),
         unique=True,
+        db_collation="case_insensitive",
     )
     full_name = models.CharField(
         _("full name"),


### PR DESCRIPTION
CI* fields are deprecated in Django 5.1