### PR TITLE
Clean pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,6 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 
--   repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.5.0
-    hooks:
-    -   id: pyproject-fmt
-
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.2
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,25 +16,6 @@ requires = [ "poetry-core>=2" ]
 [tool.poetry]
 package-mode = false
 
-[tool.poetry.group.dev.dependencies]
-# Debugging
-ipdb = "0.13.13"
-ipython = "8.31.0"
-wat-inspector = "0.4.3"
-# Formatters
-# Used by Django's find_formatters and run_formatters (with a monkey patch)
-ruff = "0.9.2"
-django-upgrade = "1.22.2"
-# Quality check
-pre-commit = "4.0.1"
-# Testing
-factory-boy = "3.3.1"
-parameterized = "0.9.0"
-tblib = "3.0.0"
-xkcdpass = "1.19.9"
-# Visualization
-pydot = "3.0.4" # For visualizing Django models with "graph_models --pydot"
-
 [tool.poetry.dependencies]
 python = "^3.13"
 celery = { extras = [ "redis" ], version = "5.4.0" }
@@ -60,6 +41,25 @@ rich = "13.9.4"
 sentry-sdk = "2.20.0"
 uuid7 = "0.1.0"
 whitenoise = "6.8.2"
+
+[tool.poetry.group.dev.dependencies]
+# Debugging
+ipdb = "0.13.13"
+ipython = "8.31.0"
+wat-inspector = "0.4.3"
+# Formatters
+# Used by Django's find_formatters and run_formatters (with a monkey patch)
+ruff = "0.9.2"
+django-upgrade = "1.22.2"
+# Quality check
+pre-commit = "4.0.1"
+# Testing
+factory-boy = "3.3.1"
+parameterized = "0.9.0"
+tblib = "3.0.0"
+xkcdpass = "1.19.9"
+# Visualization
+pydot = "3.0.4" # For visualizing Django models with "graph_models --pydot"
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-build-backend = "poetry.core.masonry.api"
-requires = [ "poetry-core>=2" ]
-
 [project]
 name = "django-blasphemy"
 version = "0.1.0"
@@ -10,9 +6,12 @@ authors = [
     { name = "Ülgen Sarıkavak", email = "ulgensrkvk@gmail.com" },
 ]
 requires-python = ">=3.13"
-classifiers = [ "Programming Language :: Python :: 3 :: Only", "Programming Language :: Python :: 3.13" ]
 # https://python-poetry.org/docs/dependency-specification#projectdependencies-and-toolpoetrydependencies
 dynamic = [ "dependencies" ]
+
+[build-system]
+build-backend = "poetry.core.masonry.api"
+requires = [ "poetry-core>=2" ]
 
 [tool.poetry]
 package-mode = false
@@ -63,13 +62,16 @@ uuid7 = "0.1.0"
 whitenoise = "6.8.2"
 
 [tool.ruff]
+line-length = 120
 target-version = "py312"
 
-line-length = 120
-format.preview = true
+[tool.ruff.format]
+preview = true
 
+[tool.ruff.lint]
+preview = true
 # https://docs.astral.sh/ruff/rules/
-lint.select = [
+select = [
     # https://docs.astral.sh/ruff/rules/#flake8-builtins-a
     # https://github.com/gforcada/flake8-builtins
     "A",
@@ -163,25 +165,22 @@ lint.select = [
     # https://github.com/PyCQA/pycodestyle
     "W",
 ]
-lint.ignore = [
+ignore = [
     # Line lengths are checked & managed by ruff, don't need to check again.
     # https://docs.astral.sh/ruff/rules/line-too-long/
     "E501",
 ]
 
+[tool.ruff.lint.per-file-ignores]
 # RUF012 is violated by Django-generated migrations.
 # Fixing them manually each time doesn't seem to add value.
 # https://docs.astral.sh/ruff/rules/mutable-class-default/
-lint.per-file-ignores."**/migrations/*" = [ "RUF012" ]
-
-# I really don't know why ruff expects two different isort sections - @ulgens
-lint.isort.known-first-party = [ "api", "core", "snippets", "users" ]
-
-lint.preview = true
+"**/migrations/*" = ["RUF012"]
 
 [tool.isort]
 # We don't use black directly but ruff uses the same profile name with isort.
 profile = "black"
 
-[tool.pyproject-fmt]
-indent = 4
+# I really don't know why ruff expects two different isort sections - @ulgens
+[tool.ruff.lint.isort]
+known-first-party = ["api", "core", "snippets", "users"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ pydot = "3.0.4" # For visualizing Django models with "graph_models --pydot"
 
 [tool.ruff]
 line-length = 120
-target-version = "py312"
+target-version = "py313"
 
 [tool.ruff.format]
 preview = true


### PR DESCRIPTION
pyproject-fmt enforces rules that I don't find useful and [the configuration options](https://pyproject-fmt.readthedocs.io/en/latest/#configuration-via-file) are limited.

With uv migration, pyproject-fmt enforces alphabetical sorting to the dependency lists - removes the context groups and custom ordering.