### PR TITLE
Don't enable beta ecosystems in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
-enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "uv"
     directory: "/"


### PR DESCRIPTION
Both uv and compose supports are in general availability now.