### PR TITLE
Add uv to pre-commit dependencies

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -54,6 +54,7 @@ jobs:
       run: >
         uv run
         --no-sync
+        --with uv==${{ env.UV_VERSION }}
         --with pre-commit==${{ env.PRE_COMMIT_VERSION }}
         --with pre-commit-uv==${{ env.PRE_COMMIT_UV_VERSION }}
         pre-commit run --all-files


### PR DESCRIPTION
pre-commit-uv doesn't use system uv and install it via pip