### PR TITLE
Fix pre-commit grouping config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -57,7 +57,7 @@
       "enabled": true
     },
     {
-      "matchDatasources": [
+      "matchManagers": [
         "pre-commit",
       ],
       "groupName": "pre-commit Dependencies",


### PR DESCRIPTION
"pre-commit" is a manager name, not a data source

https://docs.renovatebot.com/modules/manager/