### PR TITLE
Pin CI dependencies to patch version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      uses: actions/checkout@v5.0.0
 
     - name: Install uv ${{ env.UV_VERSION }} & Python ${{ env.PYTHON_VERSION }}
       id: setup-uv
@@ -33,7 +33,7 @@ jobs:
 
     - name: Cache pre-commit
       id: cache-precommit
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      uses: actions/cache@v4.2.4
       with:
         path: ~/.cache/pre-commit
         key: >

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         - 6379:6379
 
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+    - uses: actions/checkout@v5.0.0
       name: Checkout
 
     - name: Install uv ${{ env.UV_VERSION }} & Python ${{ env.PYTHON_VERSION }}


### PR DESCRIPTION
Renovate will replace these with hashes, but the pinned versions will stay as comments. When there is an update, renovate will update both hash and the comment*, and the diffs will be more clear. The comments were not updated without the pinning.

\* This is validated in https://github.com/ulgens/django-blasphemy/pull/766/files