### PR TITLE
fix: Remove the legacy Ruff lint hook ID from the .pre-commit-config.yaml file and update it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.2
     hooks:
-    -   id: ruff
+    -   id: ruff-check
         name: ruff lint
         args: ["--fix"]
     -   id: ruff-format


### PR DESCRIPTION
### Description

* Removed the old legacy Ruff hook (`ruff`)
* Added the new hook ID (`ruff-check`)

###  Why

The old pre commit hook id  `ruff` is deprecated.

### Reference

- [Official Ruff pre-commit hooks](https://github.com/astral-sh/ruff-pre-commit/blob/aad66557af3b56ba6d4d69cd1b6cba87cef50cbb/.pre-commit-hooks.yaml#L23)
- https://github.com/astral-sh/ruff-pre-commit/pull/124