### PR TITLE
Another attempt on merging Python dep groups

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -72,6 +72,9 @@
       "matchCategories": [
         "python",
       ],
+    },
+    {
+      "groupName": "Python Dependencies",
       "matchPackageNames": [
         "prek",
         "ruff", "astral-sh/ruff-pre-commit",


### PR DESCRIPTION
The previous version didn't work. It seems renovate uses only the latest "match" rule in a group.

Previous test:
- https://github.com/ulgens/django-blasphemy/pull/858