### PR TITLE
Fix filename ref

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     // https://github.com/ulgens/renovate-presets
-    "github>ulgens/renovate-presets:all",
+    "github>ulgens/renovate-presets:all.json5",
 
     // https://docs.renovatebot.com/presets-default/#assignandreviewarg0
     ":assignAndReview(ulgens)"


### PR DESCRIPTION
https://docs.renovatebot.com/config-presets/#github

"GitHub with preset name (JSON5)" method requires file extension in the ref