### PR TITLE
Remove custom git hook names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,10 +25,8 @@ repos:
     rev: v0.14.11
     hooks:
     -   id: ruff-check
-        name: ruff lint
         args: ["--fix"]
     -   id: ruff-format
-        name: ruff format
 
 -   repo: https://github.com/adamchainz/django-upgrade
     rev: 1.29.1


### PR DESCRIPTION
* ruff-check's original name is "ruff check". This feels good enough, no need to customize.
* ruff-format's original name is already "ruff format. No need to redefine the same value.