### PR TITLE
Update git hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,17 +12,17 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.24.1
+    rev: v2.25.3
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.21
+    rev: 0.11.29
     hooks:
       - id: uv-lock
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.17
+    rev: v0.15.22
     hooks:
       - id: ruff-check
         args: ["--fix"]
@@ -34,7 +34,7 @@ repos:
       - id: django-upgrade
 
   - repo: https://github.com/instrumentl/pre-commit-just
-    rev: v0.1
+    rev: v0.2
     hooks:
       - id: format-justfile
 
@@ -44,7 +44,7 @@ repos:
       - id: yamlfmt
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.3
+    rev: 0.37.4
     hooks:
       # TODO:
       #   Consider migration to actionlint
@@ -66,13 +66,13 @@ repos:
           - pyjson5==2.0.1
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.25.2
+    rev: v1.27.0
     hooks:
       - id: zizmor
         args: ["--no-progress", "--persona=auditor"]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         args: ["--ignore-words-list", "ABL, wast"]


### PR DESCRIPTION
Renovate seems to putting these in "python packages" group, not sure why: 82e340efc04cc4797805a789fb70c4309a873a72